### PR TITLE
Fix Chrome error from not responding to message

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -2,7 +2,7 @@ const BIBLE_API_KEY = '5b84d02c13d0f6135804a4aafc5f4040';
 
 // Runs the script once the page has been fully loaded
 chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
-    if (!tab.url.match(/^about:/) && info.status === 'complete') {
+    if (!tab.url.match(/^(about|chrome):/) && info.status === 'complete') {
         chrome.tabs.query({active: true, currentWindow: true}, tabs => {
             chrome.storage.sync.get(null, settings => {
                 if (settings === undefined) {

--- a/js/biblePreviewer.js
+++ b/js/biblePreviewer.js
@@ -476,7 +476,7 @@ function addLinks(elem, request) {
 }
 
 // Starts the app only once the page has completely finished loading
-chrome.runtime.onMessage.addListener(function (request) {
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     if (request.translation === undefined) {
         request.translation = DEFAULT_TRANS;
     }
@@ -492,9 +492,9 @@ chrome.runtime.onMessage.addListener(function (request) {
         }
     }
 
-    if (isCypress) {
-        addLinks(document.body, request);
+    addLinks(document.body, request);
 
+    if (isCypress) {
         let interval = setInterval(() => {
             const cypressFrame = document.querySelector('iframe').contentWindow.document.querySelector('#bible-previewer-cypress-test-container');
             if (cypressFrame) {
@@ -502,7 +502,8 @@ chrome.runtime.onMessage.addListener(function (request) {
                 clearInterval(interval);
             }
         }, 500);
-    } else {
-        addLinks(document.body, request);
     }
+
+    // Call sendResponse so the message passer knows that the request has finished
+    sendResponse();
 });

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "short_name": "BiblePreview",
   "author": "Cody Guldner",
   "description": "Turns every bible verse into a link you can hover to see the contents of the verse.",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "icons": {
     "16": "icons/bible16.png",
     "32": "icons/bible32.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bible-previewer",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bible-previewer",
-      "version": "1.3.10",
+      "version": "1.3.11",
       "license": "ISC",
       "dependencies": {
         "@popperjs/core": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bible-previewer",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Turns every bible verse into a link you can hover over to see the contents of the verse",
   "main": "biblePreviewer.js",
   "repository": {


### PR DESCRIPTION
Every time a page was loaded with the extension enabled, an error would
be logged to the background worker that there was a port closing before
the script could respond. This was because the content script wasn't
responding to the background request in the listener. Adding an empty
sendResponse call fixed the issue