### PR TITLE
Release 2.1.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "short_name": "BiblePreview",
   "author": "Cody Guldner",
   "description": "Turns every bible verse into a link you can hover to see the contents of the verse.",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "icons": {
     "16": "icons/bible16.png",
     "32": "icons/bible32.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bible-previewer",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bible-previewer",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bible-previewer",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Turns every bible verse into a link you can hover over to see the contents of the verse",
   "main": "biblePreviewer.js",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the extension version to `2.1.0` in the manifest and package metadata
- update the npm lockfile root version to match the release

## Verification
- `npm run build:prod`
- `npm run lint`