### PR TITLE
Ignore incompatible ESLint major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,12 @@ updates:
       npm:
         patterns:
           - "*"
+    ignore:
+      # Hold these until eslint-plugin-import supports ESLint 10; otherwise npm ci fails with a peer dependency conflict.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      # eslint-plugin-unicorn 72 requires ESLint 10, so keep it paired with the current ESLint 9 toolchain.
+      - dependency-name: "eslint-plugin-unicorn"
+        update-types: ["version-update:semver-major"]
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary
- Ignore Dependabot major updates for `eslint` and `eslint-plugin-unicorn`
- Add inline comments explaining the peer-dependency conflict

## Why
PR #120 bumps ESLint to v10 while `eslint-plugin-import@2.32.0` only supports ESLint through v9. `eslint-plugin-unicorn@72` also requires ESLint 10, so those major updates need to stay paired off until the ESLint 10 ecosystem is compatible.

## Validation
- Pre-commit hook ran `npm run lint` successfully

@dependabot ignore this major version

Please enable auto-merge once checks pass.